### PR TITLE
fix(core): reorg state / types

### DIFF
--- a/contracts/core/src/state/fee.rs
+++ b/contracts/core/src/state/fee.rs
@@ -5,16 +5,19 @@ use ibcx_interface::types::Units;
 use crate::error::ContractError;
 
 #[cw_serde]
+pub struct StreamingFee {
+    pub rate: Decimal,
+    pub collected: Units,
+    pub last_collected_at: u64,
+}
+
+#[cw_serde]
 pub struct Fee {
     // address of fee collector
     pub collector: Addr,
-    pub mint: Option<Decimal>,
-    pub burn: Option<Decimal>,
-    // secondly rate
-    // ex) APY %0.15 = 1 - (1 + 0.0015)^(1 / (86400 * 365)) = 0.000000000047529
-    pub stream: Option<Decimal>,
-    pub stream_collected: Units,
-    pub stream_last_collected_at: u64,
+    pub mint_fee: Option<Decimal>,
+    pub burn_fee: Option<Decimal>,
+    pub streaming_fee: Option<StreamingFee>,
 }
 
 impl Fee {

--- a/contracts/core/src/state/mod.rs
+++ b/contracts/core/src/state/mod.rs
@@ -7,34 +7,35 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Decimal, Uint128};
 use cw_storage_plus::{Item, Map};
 
-pub use fee::Fee;
+pub use fee::{Fee, StreamingFee};
 pub use pause::PauseInfo;
 pub use rebalance::{Rebalance, TradeInfo};
-pub use units::{assert_units, get_redeem_amounts, get_units, set_units};
+pub use units::Units;
 
 #[cw_serde]
-pub struct Token {
-    pub denom: String,
+pub struct Config {
+    pub gov: Addr,
+    pub paused: PauseInfo,
+    pub index_denom: String,
     pub reserve_denom: String,
-    pub total_supply: Uint128,
 }
 
 pub const RESERVE_DENOM: &str = "reserve";
 
-pub const GOV_KEY: &str = "gov";
-pub const GOV: Item<Addr> = Item::new(GOV_KEY);
+pub const CONFIG_KEY: &str = "config";
+pub const CONFIG: Item<Config> = Item::new(CONFIG_KEY);
 
 pub const FEE_KEY: &str = "fee";
 pub const FEE: Item<Fee> = Item::new(FEE_KEY);
 
-pub const TOKEN_KEY: &str = "token";
-pub const TOKEN: Item<Token> = Item::new(TOKEN_KEY);
+pub const TOTAL_SUPPLY_KEY: &str = "total_supply";
+pub const TOTAL_SUPPLY: Item<Uint128> = Item::new(TOTAL_SUPPLY_KEY);
 
-pub const PAUSED_KEY: &str = "paused";
-pub const PAUSED: Item<PauseInfo> = Item::new(PAUSED_KEY);
+pub const INDEX_UNITS_KEY: &str = "index_units";
+pub const INDEX_UNITS: Item<Units> = Item::new(INDEX_UNITS_KEY);
 
-pub const UNITS_PREFIX: &str = "assets";
-pub const UNITS: Map<String, Decimal> = Map::new(UNITS_PREFIX);
+pub const RESERVE_UNIT_KEY: &str = "reserve_unit";
+pub const RESERVE_UNIT: Item<Decimal> = Item::new(RESERVE_UNIT_KEY);
 
 pub const LATEST_REBALANCE_ID_KEY: &str = "latest_rebalance_id";
 pub const LATEST_REBALANCE_ID: Item<u64> = Item::new(LATEST_REBALANCE_ID_KEY);

--- a/contracts/core/src/state/units.rs
+++ b/contracts/core/src/state/units.rs
@@ -1,211 +1,137 @@
 use std::collections::BTreeMap;
 
-use cosmwasm_std::{coin, Coin, Order, StdResult, Storage, Uint128};
-use ibcx_interface::{types::Units, MAX_LIMIT};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{coin, Coin, Decimal, StdResult, Uint128};
 
 use crate::error::ContractError;
 
-use super::{RESERVE_DENOM, UNITS};
+pub type Unit = (String, Decimal);
 
-pub fn set_units(storage: &mut dyn Storage, assets: Units) -> Result<(), ContractError> {
-    if assets.len() > MAX_LIMIT as usize {
-        return Err(ContractError::InvalidAssetLength { limit: MAX_LIMIT });
+#[cw_serde]
+#[derive(Default)]
+pub struct Units(pub Vec<Unit>);
+
+impl Units {
+    pub fn add_key(&mut self, k: &str, v: Decimal) -> StdResult<()> {
+        match self.0.iter().position(|(denom, _)| denom == k) {
+            Some(i) => {
+                let unit = self.0.get_mut(i).unwrap();
+
+                unit.1 = unit.1.checked_add(v)?;
+            }
+            None => self.0.push((k.to_string(), v)),
+        }
+
+        Ok(())
     }
 
-    for (denom, unit) in assets {
-        if denom == RESERVE_DENOM {
-            return Err(ContractError::DenomReserved {
-                reserved: RESERVE_DENOM.to_string(),
-            });
-        }
-        match UNITS.may_load(storage, denom.clone())? {
-            Some(_) => return Err(ContractError::DenomReserved { reserved: denom }),
-            None => UNITS.save(storage, denom, &unit)?,
+    pub fn pop_key(&mut self, key: &str) -> Option<Unit> {
+        if let Some(i) = self.0.iter().position(|u| u.0 == key) {
+            Some(self.0.remove(i))
+        } else {
+            None
         }
     }
 
-    Ok(())
-}
+    pub fn calc_require_amount(&self, index_amount: Uint128) -> Vec<Coin> {
+        self.0
+            .iter()
+            .map(|(denom, unit)| coin((*unit * index_amount).u128(), denom))
+            .collect::<Vec<_>>()
+    }
 
-pub fn get_units(storage: &dyn Storage) -> StdResult<Units> {
-    UNITS
-        .range(storage, None, None, Order::Ascending)
-        .take(MAX_LIMIT as usize)
-        .collect::<StdResult<_>>()
-}
+    pub fn calc_refund_amount(
+        &self,
+        mut funds: Vec<Coin>,
+        index_amount: Uint128,
+    ) -> Result<Vec<Coin>, ContractError> {
+        let required = self.calc_require_amount(index_amount);
 
-pub fn assert_units(
-    assets: Units,
-    funds: Vec<Coin>,
-    desired: Uint128,
-) -> Result<Vec<Coin>, ContractError> {
-    assets
-        .into_iter()
-        .map(|(denom, unit)| {
-            let received = match funds.iter().find(|v| v.denom == denom) {
-                Some(c) => c,
+        for Coin { denom, amount } in required {
+            match funds.iter().position(|v| v.denom == denom) {
+                Some(i) => {
+                    let fund = funds.get_mut(i).unwrap();
+
+                    fund.amount = fund.amount.checked_sub(amount)?;
+                }
                 None => return Err(ContractError::InsufficientFunds(denom)),
-            };
+            }
+        }
 
-            let refund = received
-                .amount
-                .checked_sub(unit * desired)
-                .map_err(|_| ContractError::InsufficientFunds(denom.clone()))?;
-
-            Ok(coin(refund.u128(), denom))
-        })
-        .collect()
-}
-
-pub fn get_redeem_amounts(
-    assets: Units,
-    reserve_denom: &str,
-    desired: Uint128,
-) -> StdResult<Vec<Coin>> {
-    let mut assets: BTreeMap<_, _> = assets
-        .into_iter()
-        .map(|(denom, unit)| (denom, unit * desired))
-        .collect();
-
-    if assets.contains_key(reserve_denom) || assets.contains_key(RESERVE_DENOM) {
-        let reserve_unit = assets.get(RESERVE_DENOM).copied().unwrap_or_default();
-        assets
-            .entry(reserve_denom.to_string())
-            .and_modify(|v| *v += reserve_unit)
-            .or_insert(reserve_unit);
+        Ok(funds.into_iter().filter(|v| !v.amount.is_zero()).collect())
     }
 
-    Ok(assets
-        .into_iter()
-        .map(|(denom, amount)| coin(amount.u128(), denom))
-        .collect())
+    pub fn check_duplicate(&self) -> bool {
+        let mut uniq = BTreeMap::new();
+
+        !self
+            .0
+            .iter()
+            .all(|(denom, unit)| uniq.insert(denom.clone(), unit).is_none())
+    }
 }
 
 #[cfg(test)]
-mod test {
-    use cosmwasm_std::testing::MockStorage;
+mod tests {
+    use super::Units;
+    use cosmwasm_std::Decimal;
 
-    use crate::{
-        state::{Token, TOKEN},
-        test::{register_units, to_units},
-    };
+    #[test]
+    fn test_pop_key() {
+        let mut units = Units(vec![
+            ("uatom".to_string(), Decimal::from_ratio(1u128, 2u128)),
+            ("uosmo".to_string(), Decimal::from_ratio(1u128, 4u128)),
+        ]);
 
-    use super::*;
-
-    fn setup_test(storage: &mut dyn Storage) {
-        TOKEN
-            .save(
-                storage,
-                &Token {
-                    denom: "test".to_string(),
-                    reserve_denom: RESERVE_DENOM.to_string(),
-                    total_supply: Uint128::new(1234),
-                },
-            )
-            .unwrap();
-
-        register_units(
-            storage,
-            &[("ueur", "1.0"), ("ukrw", "1.2"), ("uusd", "1.5")],
+        // pop uatom
+        assert_eq!(
+            units.pop_key("uatom"),
+            Some(("uatom".to_string(), Decimal::from_ratio(1u128, 2u128)))
         );
+        assert_eq!(
+            units,
+            Units(vec![(
+                "uosmo".to_string(),
+                Decimal::from_ratio(1u128, 4u128)
+            )])
+        );
+
+        // pop once again
+        assert_eq!(
+            units.pop_key("uatom"),
+            None,
+            "should not be able to pop the same key twice"
+        );
+
+        // pop uosmo
+        assert_eq!(
+            units.pop_key("uosmo"),
+            Some(("uosmo".to_string(), Decimal::from_ratio(1u128, 4u128)))
+        );
+        assert_eq!(units, Units(vec![]));
     }
 
     #[test]
-    fn test_set_assets() {
-        let mut storage = MockStorage::new();
+    fn test_check_duplication() {
+        let cases = [
+            (
+                Units(vec![
+                    ("uatom".to_string(), Decimal::from_ratio(1u128, 2u128)),
+                    ("uatom".to_string(), Decimal::from_ratio(1u128, 4u128)),
+                ]),
+                true,
+            ),
+            (
+                Units(vec![
+                    ("uatom".to_string(), Decimal::from_ratio(1u128, 2u128)),
+                    ("uosmo".to_string(), Decimal::from_ratio(1u128, 4u128)),
+                ]),
+                false,
+            ),
+        ];
 
-        // check limit exceeds
-        let assets = to_units(
-            [("ukrw", "1.0")]
-                .repeat((MAX_LIMIT + 1).try_into().unwrap())
-                .as_slice(),
-        );
-        let err = set_units(&mut storage, assets).unwrap_err();
-        assert_eq!(err, ContractError::InvalidAssetLength { limit: MAX_LIMIT });
-
-        // check reserved denom
-        let assets = to_units(&[(RESERVE_DENOM, "1.0")]);
-        let err = set_units(&mut storage, assets).unwrap_err();
-        assert_eq!(
-            err,
-            ContractError::DenomReserved {
-                reserved: RESERVE_DENOM.to_string()
-            }
-        );
-
-        // check denom duplication
-        let assets = to_units(&[("ukrw", "1.0"), ("ukrw", "1.0")]);
-        let err = set_units(&mut storage, assets).unwrap_err();
-        assert_eq!(
-            err,
-            ContractError::DenomReserved {
-                reserved: "ukrw".to_string()
-            }
-        );
-        UNITS.remove(&mut storage, "ukrw".to_string());
-
-        // ok
-        let assets = to_units(&[("ukrw", "1.0"), ("ueur", "1.2"), ("uusd", "1.5")]);
-        set_units(&mut storage, assets.clone()).unwrap();
-        for (denom, unit) in assets {
-            assert_eq!(UNITS.load(&storage, denom).unwrap(), unit);
+        for (units, expect) in cases {
+            assert_eq!(units.check_duplicate(), expect);
         }
-    }
-
-    #[test]
-    fn test_get_assets() {
-        let mut storage = MockStorage::new();
-
-        setup_test(&mut storage);
-
-        let assets = get_units(&storage).unwrap();
-
-        assert_eq!(
-            assets,
-            to_units(&[("ueur", "1.0"), ("ukrw", "1.2"), ("uusd", "1.5"),])
-        );
-    }
-
-    #[test]
-    fn test_assert_assets() {
-        let mut storage = MockStorage::new();
-
-        setup_test(&mut storage);
-
-        let refund = assert_units(
-            get_units(&storage).unwrap(),
-            vec![
-                coin(12000, "ueur"),
-                coin(15000, "ukrw"),
-                coin(20000, "uusd"),
-            ],
-            Uint128::new(10000),
-        )
-        .unwrap();
-        assert_eq!(
-            refund,
-            vec![coin(2000, "ueur"), coin(3000, "ukrw"), coin(5000, "uusd"),]
-        );
-
-        let err =
-            assert_units(get_units(&storage).unwrap(), vec![], Uint128::new(10000)).unwrap_err();
-        assert_eq!(err, ContractError::InsufficientFunds("ueur".to_string()));
-    }
-
-    #[test]
-    fn test_get_redeem_amounts() {
-        let mut storage = MockStorage::new();
-
-        setup_test(&mut storage);
-
-        assert_eq!(
-            get_redeem_amounts(
-                get_units(&storage).unwrap(),
-                RESERVE_DENOM,
-                Uint128::new(10)
-            )
-            .unwrap(),
-            vec![coin(10, "ueur"), coin(12, "ukrw"), coin(15, "uusd"),]
-        );
     }
 }

--- a/packages/interface/src/core.rs
+++ b/packages/interface/src/core.rs
@@ -1,37 +1,37 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128};
 
-use crate::types::{SwapRoutes, Units};
+use crate::types::SwapRoutes;
 
 #[cw_serde]
 #[derive(Default)]
-pub struct Fee {
+pub struct FeePayload {
     pub collector: String,
-    pub mint: Option<Decimal>,
-    pub burn: Option<Decimal>,
-    pub stream: Option<Decimal>,
+    pub mint_fee: Option<Decimal>,
+    pub burn_fee: Option<Decimal>,
+    pub streaming_fee: Option<Decimal>,
 }
 
 #[cw_serde]
 #[derive(Default)]
 pub struct InstantiateMsg {
     pub gov: String,
-    pub denom: String,
+    pub fee: FeePayload,
+    pub index_denom: String,
+    pub index_units: Vec<(String, Decimal)>,
     pub reserve_denom: String,
-    pub initial_units: Units,
-    pub fee_strategy: Fee,
 }
 
 #[cw_serde]
 pub enum GovMsg {
     // pause mint / burn
     Pause {
-        expires_at: u64,
+        expires_at: Option<u64>,
     },
     Release {},
 
     UpdateGov(String),
-    UpdateFeeStrategy(Fee),
+    UpdateFeeStrategy(FeePayload),
     UpdateReserveDenom(String),
     UpdateTradeInfo {
         denom: String,
@@ -61,8 +61,8 @@ pub enum RebalanceTradeMsg {
 pub enum RebalanceMsg {
     Init {
         manager: String,
-        deflation: Units, // target units
-        inflation: Units, // conversion weights
+        deflation: Vec<(String, Decimal)>, // target units
+        inflation: Vec<(String, Decimal)>, // conversion weights
     },
     Trade(RebalanceTradeMsg),
     Finalize {},
@@ -112,14 +112,14 @@ pub enum QueryMsg {
 #[cw_serde]
 pub struct GetConfigResponse {
     pub gov: Addr,
-    pub denom: String,
+    pub index_denom: String,
     pub reserve_denom: String,
 }
 
 #[cw_serde]
 pub struct GetFeeResponse {
     pub collector: Addr,
-    pub collected: Units,
+    pub collected: Vec<(String, Decimal)>,
     pub realized: Vec<(String, Uint128)>,
     pub mint: Option<Decimal>,
     pub burn: Option<Decimal>,
@@ -137,7 +137,7 @@ pub struct GetPauseInfoResponse {
 pub struct GetPortfolioResponse {
     pub total_supply: Uint128,
     pub assets: Vec<Coin>,
-    pub units: Units,
+    pub units: Vec<(String, Decimal)>,
 }
 
 #[cw_serde]

--- a/packages/interface/src/types.rs
+++ b/packages/interface/src/types.rs
@@ -1,14 +1,12 @@
 use std::str::FromStr;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{coin, Addr, Coin, Decimal, Order, StdResult, Uint128};
+use cosmwasm_std::{coin, Addr, Coin, Order, StdResult, Uint128};
 use cosmwasm_std::{CosmosMsg, QuerierWrapper};
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
     MsgSwapExactAmountIn, MsgSwapExactAmountOut, PoolmanagerQuerier, SwapAmountInRoute,
     SwapAmountOutRoute,
 };
-
-pub type Units = Vec<(String, Decimal)>;
 
 #[cw_serde]
 pub struct SwapRoute {


### PR DESCRIPTION
* `interface::Units` -> `state::units::Units` (`type` -> `struct`)
  * `add_key`
  * `pop_key`
  * `calc_require_amount`
  * `calc_refund_amount`
  * `check_duplicate`
* `UNITS` -> `INDEX_UNITS` (`Map` -> `Item`)
* `GOV`, `TOKEN`, `PAUSED` -> `CONFIG`
* use explicit field name like `mint` -> `mint_fee`
* `interface::Fee` -> `interface::FeePayload` to prevent confusing