### PR TITLE
fix dependency issues

### DIFF
--- a/ts/sdk/package.json
+++ b/ts/sdk/package.json
@@ -58,5 +58,9 @@
     "@cosmjs/cosmwasm-stargate": "^0.30.1",
     "@tanstack/react-query": "^4.29.5",
     "cosmwasm": "^1.1.1"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/ts/sdk/rollup.config.js
+++ b/ts/sdk/rollup.config.js
@@ -26,6 +26,11 @@ function createOutputOptions(options) {
     name: "counter-sdk",
     exports: "named",
     sourcemap: true,
+    globals: {
+      "cosmjs-types/cosmwasm/wasm/v1/tx": "tx",
+      "@cosmjs/encoding": "encoding",
+      "@tanstack/react-query": "reactQuery",
+    },
     ...options,
   };
 }
@@ -68,6 +73,11 @@ const options = {
       useTsconfigDeclarationDir: true,
       tsconfig: "./tsconfig.bundle.json",
     }),
+  ],
+  external: [
+    "@tanstack/react-query",
+    "cosmjs-types/cosmwasm/wasm/v1/tx",
+    "@cosmjs/encoding",
   ],
 };
 


### PR DESCRIPTION
# issue 1
```
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
@tanstack/react-query (imported by src/contracts/Airdrop.react-query.ts, src/contracts/Core.react-query.ts, src/contracts/Faucet.react-query.ts)
cosmjs-types/cosmwasm/wasm/v1/tx (imported by src/contracts/Airdrop.message-composer.ts, src/contracts/Core.message-composer.ts, src/contracts/Faucet.message-composer.ts, src/contracts/Periphery.message-composer.ts)
@cosmjs/encoding (imported by src/contracts/Airdrop.message-composer.ts, src/contracts/Core.message-composer.ts, src/contracts/Faucet.message-composer.ts, src/contracts/Periphery.message-composer.ts)
```

위 warning은 Rollup에서 특정 모듈이 외부 종속성으로 취급되어야 함을 알려주고 있습니다. [Treating Modules as External dependency](https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency) 문서에 따라 외부 모듈을을 따로 선언합니다.

만약 위 방법이을 적용해도, ibcx-contract 패키지를 설치했을때 의존성 관련된 문제가 계속된다면, `@rollup/plugin-node-resolve` 플러그인을 사용해서 의존성을 패키지에 포함시키는 방법이 있습니다.


# issue 2
```
(!) Missing global variable names
Use output.globals to specify browser global variable names corresponding to external modules
cosmjs-types/cosmwasm/wasm/v1/tx (guessing 'tx')
@cosmjs/encoding (guessing 'encoding')
@tanstack/react-query (guessing 'reactQuery')
cosmjs-types/cosmwasm/wasm/v1/tx (guessing 'tx')
@cosmjs/encoding (guessing 'encoding')
@tanstack/react-query (guessing 'reactQuery')
```

이 에러는 Rollup이 외부 모듈을 번들링할 때 해당 모듈이 전역 변수로 어떻게 노출될지 결정할 수 없기 때문에 발생합니다. 이를 해결하기 위해서는 Rollup의 output.globals 설정을 사용하여 전역 변수 이름을 지정해주어야 합니다.

